### PR TITLE
Add PostgreSQL sink with new Sink API

### DIFF
--- a/java/merger-flink/pom.xml
+++ b/java/merger-flink/pom.xml
@@ -76,6 +76,11 @@
             <artifactId>serialization</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.7.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/java/merger-flink/pom.xml
+++ b/java/merger-flink/pom.xml
@@ -18,6 +18,7 @@
         <flink.version>1.20.0</flink.version>
         <flink.kafka.version>3.3.0-1.20</flink.kafka.version>
         <scala.binary.version>2.12</scala.binary.version>
+        <postgres.version>42.7.4</postgres.version>
     </properties>
 
     <repositories>
@@ -79,7 +80,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.2</version>
+            <version>${postgres.version}</version>
         </dependency>
     </dependencies>
 

--- a/java/merger-flink/src/main/java/cz/vut/fit/domainradar/CommonDeserializer.java
+++ b/java/merger-flink/src/main/java/cz/vut/fit/domainradar/CommonDeserializer.java
@@ -4,22 +4,30 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import cz.vut.fit.domainradar.models.results.Result;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 
 public abstract class CommonDeserializer {
     private transient JsonFactory _jsonFactory;
 
+    public record StatusMeta(int statusCode, @Nullable String error) {
+    }
+
     /**
-     * Parses the status code only from a JSON-serialized {@link Result}.
+     * Parses the status code and error message only from a JSON-serialized {@link Result}.
      *
      * @param resultInput The bytes of a JSON-serialized Result.
      * @return The status code.
      */
-    public int parseStatusCode(byte[] resultInput) {
+    public StatusMeta parseStatusMeta(byte[] resultInput) {
         if (_jsonFactory == null) {
             _jsonFactory = new JsonFactory();
         }
+
+        int statusCode = -1;
+        String error = null;
+        boolean gotOne = false;
 
         try (JsonParser parser = _jsonFactory.createParser(resultInput)) {
             // Start parsing the JSON
@@ -34,15 +42,25 @@ public abstract class CommonDeserializer {
                     if ("statusCode".equals(fieldName)) {
                         // Move to the next token which is the value of "statusCode"
                         parser.nextToken();
-                        return parser.getIntValue();
+                        statusCode = parser.getIntValue();
+                        if (gotOne) break;
+                        gotOne = true;
+                    } else if ("error".equals(fieldName)) {
+                        if (parser.nextToken() == JsonToken.VALUE_NULL) {
+                            error = null;
+                        } else {
+                            error = parser.getText();
+                        }
+                        if (gotOne) break;
+                        gotOne = true;
                     }
                 }
             }
         } catch (IOException e) {
             // TODO: Log?
-            return -1;
+            return new StatusMeta(statusCode, error);
         }
 
-        return -1;
+        return new StatusMeta(statusCode, error);
     }
 }

--- a/java/merger-flink/src/main/java/cz/vut/fit/domainradar/IPEntriesProcessFunction.java
+++ b/java/merger-flink/src/main/java/cz/vut/fit/domainradar/IPEntriesProcessFunction.java
@@ -204,7 +204,8 @@ public class IPEntriesProcessFunction extends KeyedCoProcessFunction<String, Kaf
         var expectedIps = new HashMap<String, Map<Byte, KafkaIPEntry>>();
         for (var gotEntries : _expectedIpsToNumberOfEntries.entries()) {
             if (gotEntries.getValue() < TOTAL_EXPECTED_RECORDS_PER_IPS) {
-                LOG.trace("[{}] Not enough collected data object for an IP", key);
+                LOG.trace("[{}] Not enough collected data objects ({}) for IP {}", key,
+                        gotEntries.getValue(), gotEntries.getKey());
                 return;
             }
 

--- a/java/merger-flink/src/main/java/cz/vut/fit/domainradar/KafkaDomainEntry.java
+++ b/java/merger-flink/src/main/java/cz/vut/fit/domainradar/KafkaDomainEntry.java
@@ -1,6 +1,7 @@
 package cz.vut.fit.domainradar;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A POJO representing a Kafka record with a string key.
@@ -12,23 +13,27 @@ public class KafkaDomainEntry implements KafkaEntry {
     String domainName;
     byte @NotNull [] value;
     int statusCode;
+
+    @Nullable
+    String error;
+
     @NotNull
     String topic;
     int partition;
     long offset;
     long timestamp;
-
     public KafkaDomainEntry() {
         this.domainName = "";
         this.topic = "";
         this.value = new byte[0];
     }
 
-    public KafkaDomainEntry(@NotNull String domainName, byte @NotNull [] value, int statusCode, @NotNull String topic,
-                            int partition, long offset, long timestamp) {
+    public KafkaDomainEntry(@NotNull String domainName, byte @NotNull [] value, int statusCode, @Nullable String error,
+                            @NotNull String topic, int partition, long offset, long timestamp) {
         this.domainName = domainName;
         this.value = value;
         this.statusCode = statusCode;
+        this.error = error;
         this.topic = topic;
         this.partition = partition;
         this.offset = offset;
@@ -58,6 +63,14 @@ public class KafkaDomainEntry implements KafkaEntry {
 
     public void setStatusCode(int statusCode) {
         this.statusCode = statusCode;
+    }
+
+    public @Nullable String getError() {
+        return error;
+    }
+
+    public void setError(@Nullable String error) {
+        this.error = error;
     }
 
     @NotNull

--- a/java/merger-flink/src/main/java/cz/vut/fit/domainradar/KafkaDomainEntryDeserializer.java
+++ b/java/merger-flink/src/main/java/cz/vut/fit/domainradar/KafkaDomainEntryDeserializer.java
@@ -7,8 +7,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 
-import java.io.IOException;
-
 public class KafkaDomainEntryDeserializer
         extends CommonDeserializer
         implements KafkaRecordDeserializationSchema<KafkaDomainEntry> {
@@ -21,10 +19,10 @@ public class KafkaDomainEntryDeserializer
         }
 
         String key = _keyDeserializer.deserialize(consumerRecord.topic(), consumerRecord.key());
-        int statusCode = parseStatusCode(consumerRecord.value());
+        var statusMeta = this.parseStatusMeta(consumerRecord.value());
 
-        collector.collect(new KafkaDomainEntry(key, consumerRecord.value(), statusCode, consumerRecord.topic(),
-                consumerRecord.partition(), consumerRecord.offset(), consumerRecord.timestamp()));
+        collector.collect(new KafkaDomainEntry(key, consumerRecord.value(), statusMeta.statusCode(), statusMeta.error(),
+                consumerRecord.topic(), consumerRecord.partition(), consumerRecord.offset(), consumerRecord.timestamp()));
     }
 
     @Override

--- a/java/merger-flink/src/main/java/cz/vut/fit/domainradar/KafkaIPEntry.java
+++ b/java/merger-flink/src/main/java/cz/vut/fit/domainradar/KafkaIPEntry.java
@@ -1,6 +1,7 @@
 package cz.vut.fit.domainradar;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A tuple representing a Kafka record with a (domain name, IP) pair key.
@@ -14,6 +15,8 @@ public class KafkaIPEntry implements KafkaEntry {
     String ip;
     byte @NotNull [] value;
     int statusCode;
+    @Nullable
+    String error;
     byte collectorTag;
     @NotNull
     String topic;
@@ -29,11 +32,13 @@ public class KafkaIPEntry implements KafkaEntry {
     }
 
     public KafkaIPEntry(@NotNull String domainName, @NotNull String ip, byte @NotNull [] value, int statusCode,
-                        byte collectorTag, @NotNull String topic, int partition, long offset, long timestamp) {
+                        @Nullable String error, byte collectorTag,
+                        @NotNull String topic, int partition, long offset, long timestamp) {
         this.domainName = domainName;
         this.ip = ip;
         this.value = value;
         this.statusCode = statusCode;
+        this.error = error;
         this.collectorTag = collectorTag;
         this.topic = topic;
         this.partition = partition;
@@ -114,5 +119,13 @@ public class KafkaIPEntry implements KafkaEntry {
 
     public void setCollectorTag(byte collectorTag) {
         this.collectorTag = collectorTag;
+    }
+
+    public @Nullable String getError() {
+        return error;
+    }
+
+    public void setError(@Nullable String error) {
+        this.error = error;
     }
 }

--- a/java/merger-flink/src/main/java/cz/vut/fit/domainradar/KafkaIPEntryDeserializer.java
+++ b/java/merger-flink/src/main/java/cz/vut/fit/domainradar/KafkaIPEntryDeserializer.java
@@ -35,7 +35,7 @@ public class KafkaIPEntryDeserializer
         IPToProcess key = _keyDeserializer.deserialize(consumerRecord.topic(), consumerRecord.key());
 
         var value = consumerRecord.value();
-        int statusCode = parseStatusCode(value);
+        var statusMeta = this.parseStatusMeta(value);
 
         // TODO: Use tags
         // byte collectorTag = value[value.length - 1];
@@ -48,8 +48,8 @@ public class KafkaIPEntryDeserializer
         }
         var collectorTag = collectorTagOrNull.byteValue();
         collector.collect(new KafkaIPEntry(key.dn(), key.ip(), consumerRecord.value(),
-                statusCode, collectorTag, consumerRecord.topic(), consumerRecord.partition(),
-                consumerRecord.offset(), consumerRecord.timestamp()));
+                statusMeta.statusCode(), statusMeta.error(), collectorTag, consumerRecord.topic(),
+                consumerRecord.partition(), consumerRecord.offset(), consumerRecord.timestamp()));
     }
 
     @Override

--- a/java/merger-flink/src/main/java/cz/vut/fit/domainradar/db/PostgresCollectorResultSink.java
+++ b/java/merger-flink/src/main/java/cz/vut/fit/domainradar/db/PostgresCollectorResultSink.java
@@ -1,0 +1,408 @@
+package cz.vut.fit.domainradar.db;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import cz.vut.fit.domainradar.Common;
+import cz.vut.fit.domainradar.KafkaDomainAggregate;
+import cz.vut.fit.domainradar.KafkaDomainEntry;
+import cz.vut.fit.domainradar.KafkaIPEntry;
+import cz.vut.fit.domainradar.KafkaMergedResult;
+import cz.vut.fit.domainradar.Topics;
+import cz.vut.fit.domainradar.models.ip.GeoIPData;
+import cz.vut.fit.domainradar.models.ip.NERDData;
+import cz.vut.fit.domainradar.models.results.CommonIPResult;
+import cz.vut.fit.domainradar.serialization.TagRegistry;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.sql.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A Flink sink that stores {@link KafkaMergedResult} objects into a PostgreSQL database.
+ * It performs the same operations as the former {@code process_collection_results()} procedure.
+ */
+public class PostgresCollectorResultSink implements Sink<KafkaMergedResult> {
+    public static final String COMPONENT_NAME = "postgres-sink";
+
+    private final String dbUrl;
+    private final String dbUser;
+    private final String dbPassword;
+
+    public PostgresCollectorResultSink(String dbUrl, String dbUser, String dbPassword) {
+        this.dbUrl = Objects.requireNonNull(dbUrl, "dbUrl");
+        this.dbUser = dbUser;
+        this.dbPassword = dbPassword;
+    }
+
+    @Override
+    public SinkWriter<KafkaMergedResult> createWriter(InitContext context) throws IOException {
+        try {
+            return new PgWriter();
+        } catch (SQLException e) {
+            throw new IOException(e);
+        }
+    }
+
+    private class PgWriter implements SinkWriter<KafkaMergedResult> {
+        private final Logger LOG = Common.getComponentLogger(PostgresCollectorResultSink.class);
+
+        private final Connection connection;
+        private final PreparedStatement selectDomain;
+        private final PreparedStatement insertDomain;
+        private final PreparedStatement selectIp;
+        private final PreparedStatement insertIp;
+        private final PreparedStatement insertResult;
+        private final PreparedStatement insertDomainError;
+        private final ObjectMapper mapper;
+        private final Map<String, CollectorInfo> collectorCache = new HashMap<>();
+        private final TypeReference<CommonIPResult<GeoIPData>> geoRef = new TypeReference<>() {};
+        private final TypeReference<CommonIPResult<NERDData>> nerdRef = new TypeReference<>() {};
+        private final TypeReference<CommonIPResult<Object>> genericRef = new TypeReference<>() {};
+
+        PgWriter() throws SQLException {
+            connection = DriverManager.getConnection(dbUrl, dbUser, dbPassword);
+            connection.setAutoCommit(false);
+
+            selectDomain = connection.prepareStatement("SELECT id FROM Domain WHERE domain_name = ?");
+            insertDomain = connection.prepareStatement(
+                    "INSERT INTO Domain(domain_name, last_update) VALUES (?, ?) RETURNING id");
+            selectIp = connection.prepareStatement(
+                    "SELECT id FROM IP WHERE domain_id = ? AND ip = ?::inet");
+            insertIp = connection.prepareStatement(
+                    "INSERT INTO IP(domain_id, ip) VALUES (?, ?::inet) ON CONFLICT(domain_id, ip) DO NOTHING RETURNING id");
+            insertResult = connection.prepareStatement(
+                    "INSERT INTO Collection_Result(domain_id, ip_id, source_id, status_code, error, timestamp, raw_data)" +
+                            " VALUES (?, ?, ?, ?, ?, ?, ?::jsonb)" +
+                            " ON CONFLICT ON CONSTRAINT collection_result_unique DO UPDATE" +
+                            " SET status_code=EXCLUDED.status_code, error=EXCLUDED.error, raw_data=EXCLUDED.raw_data");
+            insertDomainError = connection.prepareStatement(
+                    "INSERT INTO Domain_Errors(domain_id, timestamp, source, error, sql_error_code, sql_error_message)" +
+                            " VALUES (?, ?, ?, ?, ?, ?)");
+            mapper = Common.makeMapper().build();
+        }
+
+        @Override
+        public void write(KafkaMergedResult value, Context context) throws IOException {
+            try {
+                processResult(value);
+                connection.commit();
+            } catch (Exception e) {
+                try {
+                    connection.rollback();
+                } catch (SQLException ex) {
+                    LOG.error("Rollback failed", ex);
+                }
+                throw new IOException("Failed to store merged result", e);
+            }
+        }
+
+        @Override
+        public void flush(boolean endOfInput) throws IOException {
+            try {
+                connection.commit();
+            } catch (SQLException e) {
+                throw new IOException(e);
+            }
+        }
+
+        @Override
+        public void close() throws Exception {
+            connection.close();
+        }
+
+        private void processResult(KafkaMergedResult merged) throws Exception {
+            var domainName = merged.getDomainName();
+            long ts = earliestTimestamp(merged);
+            long domainId = getOrCreateDomain(domainName, ts);
+
+            Map<String, Long> ipIds = new HashMap<>();
+            if (merged.getIPData() != null) {
+                for (var ipEntry : merged.getIPData().entrySet()) {
+                    var ipId = getOrCreateIp(domainId, ipEntry.getKey());
+                    ipIds.put(ipEntry.getKey(), ipId);
+                }
+            }
+
+            // Domain based results
+            var domainData = merged.getDomainData();
+            handleDomainEntry(domainId, domainData.getZoneData());
+            handleDomainEntry(domainId, domainData.getDNSData());
+            handleDomainEntry(domainId, domainData.getRDAPData());
+            handleDomainEntry(domainId, domainData.getTLSData());
+
+            // IP based results
+            if (merged.getIPData() != null) {
+                for (var ipEntry : merged.getIPData().entrySet()) {
+                    var ipId = ipIds.get(ipEntry.getKey());
+                    for (var collectorEntry : ipEntry.getValue().entrySet()) {
+                        handleIpEntry(domainId, ipId, collectorEntry.getKey(), collectorEntry.getValue());
+                    }
+                }
+            }
+        }
+
+        private long getOrCreateDomain(String domainName, long timestamp) throws SQLException {
+            selectDomain.setString(1, domainName);
+            try (var rs = selectDomain.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getLong(1);
+                }
+            }
+            insertDomain.setString(1, domainName);
+            insertDomain.setTimestamp(2, new Timestamp(timestamp));
+            try (var rs = insertDomain.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getLong(1);
+                }
+            }
+            selectDomain.setString(1, domainName);
+            try (var rs = selectDomain.executeQuery()) {
+                rs.next();
+                return rs.getLong(1);
+            }
+        }
+
+        private long getOrCreateIp(long domainId, String ip) throws SQLException {
+            selectIp.setLong(1, domainId);
+            selectIp.setString(2, ip);
+            try (var rs = selectIp.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getLong(1);
+                }
+            }
+            insertIp.setLong(1, domainId);
+            insertIp.setString(2, ip);
+            try (var rs = insertIp.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getLong(1);
+                }
+            } catch (SQLException e) {
+                insertIp.setLong(1, domainId);
+                insertIp.setString(2, "0.0.0.0");
+                try (var rs2 = insertIp.executeQuery()) {
+                    if (rs2.next()) {
+                        return rs2.getLong(1);
+                    }
+                }
+            }
+            selectIp.setLong(1, domainId);
+            selectIp.setString(2, ip);
+            try (var rs = selectIp.executeQuery()) {
+                rs.next();
+                return rs.getLong(1);
+            }
+        }
+
+        private void handleDomainEntry(long domainId, KafkaDomainEntry entry) throws Exception {
+            if (entry == null) {
+                return;
+            }
+            String collector = Topics.TOPICS_TO_COLLECTOR_ID.get(entry.getTopic());
+            if (collector == null) {
+                insertDomainError(domainId, entry.getTimestamp(), COMPONENT_NAME,
+                        "Unknown collector: " + entry.getTopic(), null);
+                return;
+            }
+            CollectorInfo ci = getCollectorInfo(domainId, entry.getTimestamp(), collector);
+            if (ci == null) {
+                return;
+            }
+            JsonNode node = parseJson(domainId, entry.getTimestamp(), entry.getValue());
+            String error = node != null && node.hasNonNull("error") ? node.get("error").asText() : null;
+            insertCollectionResult(domainId, null, ci.id, entry.getStatusCode(), error,
+                    entry.getTimestamp(), entry.getValue());
+        }
+
+        private void handleIpEntry(long domainId, long ipId, byte collectorTag, KafkaIPEntry entry) throws Exception {
+            String collector = TagRegistry.COLLECTOR_NAMES.get((int) collectorTag);
+            if (collector == null) {
+                insertDomainError(domainId, entry.getTimestamp(), COMPONENT_NAME,
+                        "Unknown collector tag: " + collectorTag, null);
+                return;
+            }
+            CollectorInfo ci = getCollectorInfo(domainId, entry.getTimestamp(), collector);
+            if (ci == null) {
+                return;
+            }
+            var result = parseIpResult(domainId, entry.getTimestamp(), collector, entry.getValue());
+            String error = result == null ? null : result.error();
+            insertCollectionResult(domainId, ipId, ci.id, entry.getStatusCode(), error,
+                    entry.getTimestamp(), entry.getValue());
+            if (result != null && entry.getStatusCode() == 0) {
+                if ("geo-asn".equals(collector)) {
+                    updateGeoIpData(ipId, ((CommonIPResult<GeoIPData>) result).data(), entry.getTimestamp());
+                } else if ("nerd".equals(collector)) {
+                    updateNerdData(ipId, ((CommonIPResult<NERDData>) result).data(), entry.getTimestamp());
+                }
+            }
+        }
+
+        private JsonNode parseJson(long domainId, long ts, byte[] data) throws SQLException {
+            try {
+                return mapper.readTree(data);
+            } catch (Exception e) {
+                insertDomainError(domainId, ts, COMPONENT_NAME, "Cannot parse JSON.", e);
+                return null;
+            }
+        }
+
+        private CommonIPResult<?> parseIpResult(long domainId, long ts, String collector, byte[] data) throws SQLException {
+            try {
+                if ("geo-asn".equals(collector)) {
+                    return mapper.readValue(data, geoRef);
+                } else if ("nerd".equals(collector)) {
+                    return mapper.readValue(data, nerdRef);
+                } else {
+                    return mapper.readValue(data, genericRef);
+                }
+            } catch (Exception e) {
+                insertDomainError(domainId, ts, COMPONENT_NAME, "Cannot parse JSON.", e);
+                return null;
+            }
+        }
+
+        private void insertDomainError(long domainId, long ts, String source, String message, Exception e) throws SQLException {
+            insertDomainError.setLong(1, domainId);
+            insertDomainError.setTimestamp(2, new Timestamp(ts));
+            insertDomainError.setString(3, source);
+            insertDomainError.setString(4, message);
+            if (e instanceof SQLException se) {
+                insertDomainError.setString(5, se.getSQLState());
+                insertDomainError.setString(6, se.getMessage());
+            } else {
+                insertDomainError.setNull(5, Types.VARCHAR);
+                insertDomainError.setString(6, e == null ? null : e.getMessage());
+            }
+            insertDomainError.executeUpdate();
+        }
+
+        private CollectorInfo getCollectorInfo(long domainId, long ts, String name) throws SQLException {
+            CollectorInfo ci = collectorCache.get(name);
+            if (ci != null) return ci;
+            try (var ps = connection.prepareStatement("SELECT id, is_ip_collector FROM Collector WHERE collector = ?")) {
+                ps.setString(1, name);
+                try (var rs = ps.executeQuery()) {
+                    if (rs.next()) {
+                        ci = new CollectorInfo(rs.getShort(1), rs.getBoolean(2));
+                        collectorCache.put(name, ci);
+                        return ci;
+                    }
+                }
+            }
+            insertDomainError(domainId, ts, COMPONENT_NAME, "Unknown collector: " + name, null);
+            return null;
+        }
+
+        private void insertCollectionResult(long domainId, Long ipId, short collectorId, int statusCode,
+                                            String error, long ts, byte[] rawData) throws SQLException {
+            insertResult.setLong(1, domainId);
+            if (ipId == null) {
+                insertResult.setNull(2, Types.BIGINT);
+            } else {
+                insertResult.setLong(2, ipId);
+            }
+            insertResult.setShort(3, collectorId);
+            insertResult.setInt(4, statusCode);
+            if (error == null) {
+                insertResult.setNull(5, Types.VARCHAR);
+            } else {
+                insertResult.setString(5, error);
+            }
+            insertResult.setTimestamp(6, new Timestamp(ts));
+            insertResult.setString(7, new String(rawData));
+            insertResult.executeUpdate();
+        }
+
+        private void updateGeoIpData(long ipId, GeoIPData data, long ts) throws SQLException {
+            if (ipId == 0 || data == null) return;
+            try (PreparedStatement ps = connection.prepareStatement(
+                    "UPDATE IP SET geo_country_code=?, geo_region=?, geo_region_code=?, geo_city=?," +
+                            " geo_postal_code=?, geo_latitude=?, geo_longitude=?, geo_timezone=?," +
+                            " asn=?, as_org=?, network_address=?, network_prefix_length=?," +
+                            " geo_asn_update_timestamp=? WHERE id=?" +
+                            " AND (geo_asn_update_timestamp IS NULL OR geo_asn_update_timestamp <= ?)")) {
+                ps.setString(1, data.countryCode());
+                ps.setString(2, data.region());
+                ps.setString(3, data.regionCode());
+                ps.setString(4, data.city());
+                ps.setString(5, data.postalCode());
+                setDoubleOrNull(ps, 6, data.latitude());
+                setDoubleOrNull(ps, 7, data.longitude());
+                ps.setString(8, data.timezone());
+                setLongOrNull(ps, 9, data.asn());
+                ps.setString(10, data.asnOrg());
+                ps.setString(11, data.networkAddress());
+                setIntOrNull(ps, 12, data.prefixLength() == null ? null : data.prefixLength().intValue());
+                Timestamp tsObj = new Timestamp(ts);
+                ps.setTimestamp(13, tsObj);
+                ps.setLong(14, ipId);
+                ps.setTimestamp(15, tsObj);
+                ps.executeUpdate();
+            }
+        }
+
+        private void updateNerdData(long ipId, NERDData data, long ts) throws SQLException {
+            if (ipId == 0 || data == null) return;
+            try (PreparedStatement ps = connection.prepareStatement(
+                    "UPDATE IP SET nerd_reputation=?, nerd_update_timestamp=? WHERE id=?" +
+                            " AND (nerd_update_timestamp IS NULL OR nerd_update_timestamp <= ?)")) {
+                setDoubleOrNull(ps, 1, data.reputation());
+                Timestamp tsObj = new Timestamp(ts);
+                ps.setTimestamp(2, tsObj);
+                ps.setLong(3, ipId);
+                ps.setTimestamp(4, tsObj);
+                ps.executeUpdate();
+            }
+        }
+
+        private void setDoubleOrNull(PreparedStatement ps, int idx, Double n) throws SQLException {
+            if (n == null) {
+                ps.setNull(idx, Types.DOUBLE);
+            } else {
+                ps.setDouble(idx, n);
+            }
+        }
+
+        private void setLongOrNull(PreparedStatement ps, int idx, Long n) throws SQLException {
+            if (n == null) {
+                ps.setNull(idx, Types.BIGINT);
+            } else {
+                ps.setLong(idx, n);
+            }
+        }
+
+        private void setIntOrNull(PreparedStatement ps, int idx, Integer n) throws SQLException {
+            if (n == null) {
+                ps.setNull(idx, Types.INTEGER);
+            } else {
+                ps.setInt(idx, n);
+            }
+        }
+
+        private long earliestTimestamp(KafkaMergedResult merged) {
+            long ts = Long.MAX_VALUE;
+            KafkaDomainAggregate d = merged.getDomainData();
+            if (d.getZoneData() != null) ts = Math.min(ts, d.getZoneData().getTimestamp());
+            if (d.getDNSData() != null) ts = Math.min(ts, d.getDNSData().getTimestamp());
+            if (d.getRDAPData() != null) ts = Math.min(ts, d.getRDAPData().getTimestamp());
+            if (d.getTLSData() != null) ts = Math.min(ts, d.getTLSData().getTimestamp());
+            if (merged.getIPData() != null) {
+                for (var ip : merged.getIPData().values()) {
+                    for (KafkaIPEntry e : ip.values()) {
+                        ts = Math.min(ts, e.getTimestamp());
+                    }
+                }
+            }
+            if (ts == Long.MAX_VALUE) ts = System.currentTimeMillis();
+            return ts;
+        }
+    }
+
+    private record CollectorInfo(short id, boolean isIpCollector) { }
+}

--- a/python/publish_one.py
+++ b/python/publish_one.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+import argparse
+import datetime
+import json
+import tomllib
+from time import sleep
+
+from confluent_kafka import Producer
+
+
+def make_client_settings(config: dict) -> dict:
+    ret = {
+        "bootstrap.servers": ",".join(config["connection"]["brokers"]),
+    }
+
+    if config["connection"]["use_ssl"]:
+        ret["security.protocol"] = "SSL"
+        ret["ssl.ca.location"] = config["connection"]["ssl"]["ca_file"]
+        ret["ssl.certificate.location"] = config["connection"]["ssl"]["client_cert_file"]
+        ret["ssl.key.location"] = config["connection"]["ssl"]["client_key_file"]
+        ret["ssl.key.password"] = config["connection"]["ssl"]["client_key_password"]
+        ret["ssl.endpoint.identification.algorithm"] = \
+            "https" if config["connection"]["ssl"]["check_hostname"] else "none"
+
+    return ret
+
+
+def make_producer_settings(config: dict) -> dict:
+    ret = make_client_settings(config)
+    ret = ret | config.get("producer", {})
+
+    return ret
+
+
+def delivery_report(err, msg):
+    """Callback for message delivery reports."""
+    if err is not None:
+        print(f"Delivery failed for record {msg.key()}: {err}")
+    # else: delivery succeeded; do nothing
+
+
+def load_json(path):
+    with open(path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def dumps_tight(obj):
+    """Serialize an object to a JSON string without extra spaces."""
+    return json.dumps(obj, indent=None, separators=(",", ":"))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Publish JSON subsections to Kafka topics"
+    )
+    parser.add_argument("config", help="Path to configuration file")
+    parser.add_argument("domain_name", help="Domain name to use as message key")
+    parser.add_argument("data_file", help="Path to JSON input file")
+    args = parser.parse_args()
+
+    domain = args.domain_name
+    data = load_json(args.data_file)
+
+    # Configure Kafka producer
+    with open(args.config, "rb") as f:
+        config = tomllib.load(f)
+
+    producer = Producer(make_producer_settings(config))
+
+    # Mapping from JSON field to Kafka topic
+    section_topics = {
+        "zone": "processed_zone",
+        "dnsResult": "processed_DNS",
+        "tlsResult": "processed_TLS",
+        "rdapDomainResult": "processed_RDAP_DN",
+    }
+
+    # Transform the zone data into a result
+    if "zone" in data:
+        current_timestamp = int(datetime.datetime.now().timestamp() * 1000)
+        data["zone"] = {
+            "statusCode": 0,
+            "error": None,
+            "lastAttempt": data.get("dnsResult", {}).get("lastAttempt", current_timestamp) - 500,
+            "zone": data["zone"]
+        }
+
+    # Publish top-level sections
+    for section, topic in section_topics.items():
+        payload = data.get(section)
+        if payload is not None:
+            producer.produce(
+                topic=topic,
+                key=domain,
+                value=dumps_tight(payload),
+                callback=delivery_report
+            )
+            producer.poll(0)
+            print(f"Published {section} data to {topic}")
+            sleep(0.4)
+
+    # Publish IP-based collected data
+    ip_results = data.get("ipResults", {})
+    for ip, collectors in ip_results.items():
+        for collector_name, result in collectors.items():
+            key_obj = {"dn": domain, "ip": ip}
+            producer.produce(
+                topic="collected_IP_data",
+                key=dumps_tight(key_obj),
+                value=dumps_tight(result),
+                callback=delivery_report
+            )
+            producer.poll(0)
+            print(f"Published {collector_name} data for {ip} to collected_IP_data")
+            sleep(0.3)
+
+    # Ensure all messages are delivered
+    producer.flush()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- migrate PostgresCollectorResultSink to `org.apache.flink.api.connector.sink2.Sink`
- pass DB credentials from app properties and attach sink using `sinkTo`
- update IP handling to deserialize GeoASN/NERD data into POJOs

## Testing
- `mvn -q -pl java/merger-flink test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849724f9184833291d93b348629692a